### PR TITLE
[소재희] feat: update sorting logic on comparison status page

### DIFF
--- a/controller/startupController.js
+++ b/controller/startupController.js
@@ -23,11 +23,24 @@ export const getStartups = async (req, res) => {
     createdAt: "createdAt",
   };
   const orderField = orderMapping[order] || "createdAt";
+  /*
   // 1차 정렬(orderField), 2차 정렬(id) 설정
   const orderBy = [
     { [orderField]: safeSort },
     { id: "asc" }, // 동점일 경우 id로 2차 정렬
   ];
+  */
+
+  // 1차 정렬
+  let orderBy = [{ [orderField]: safeSort }];
+
+  // order 옵션에 따른 2차 정렬
+  if (order === "selected_count") {
+    orderBy.push({ comparedCount: safeSort }); // 2차 정렬 compared_count
+  } else if (order === "compared_count") {
+    orderBy.push({ selectedCount: safeSort }); // 2차 정렬 selected_count
+  }
+  orderBy.push({ id: "asc" }); // 모든 경우에 2차 또는 3차 정렬로 id로 추가  
 
   const where = {
     AND: [

--- a/http/startups.http
+++ b/http/startups.http
@@ -31,11 +31,11 @@ GET http://localhost:3000/api/startups/4/rank?order=revenu&sort=desc
 ###
 GET http://localhost:3000/api/startups/7/rank?order=employee_count&sort=desc
 
-###
-GET http://localhost:3000/api/startups?order=selected_count&sort=desc&page=1&limit=10
+### 비교현황 (나의기업 선택횟수 순)
+GET http://localhost:3000/api/startups?order=selected_count&sort=desc&page=1&limit=20
 
-###
-GET http://localhost:3000/api/startups?order=compared_count&sort=desc&page=1&limit=10
+### 비교현황 (비교기업 선택횟수 순)
+GET http://localhost:3000/api/startups?order=compared_count&sort=desc&page=1&limit=20
 
 ### ID 1번 스타트업의 상세 정보및 투자자 가져오기 ( 1page )
 GET http://localhost:3000/api/startups/1?page=1&limit=10


### PR DESCRIPTION
### 비교현황에서 sorting 알고리즘 변경
* 정렬이 나의 기업 선택 횟수 기준일 경우, 비교 기업 선택 횟수를 2차 정렬로 추가
* 정렬이 비교 기업 선택 횟수 기준일 경우, 나의 기업 선택 횟수를 2차 정렬로 추가
* 마지막에 id (sqeuence) 로 추가 정렬하여, API 요청시 동률인 경우에도 항상 동일한 결과를 응답을 할 수 있도록 함